### PR TITLE
Corrected "Learn More" link from /Speakers/Details/# to /Sessions/Details/#

### DIFF
--- a/Views/Sessions/Index.cshtml
+++ b/Views/Sessions/Index.cshtml
@@ -83,7 +83,7 @@
                 @(item.Track!=null?string.Format("{0}",item.Track.RoomNumber):string.Empty)
             </div>
             <div>
-                @(((!(string.IsNullOrEmpty(item.Description) ))? item.Description.Substring(0,Math.Min(200,item.Description.Length)):"N/A")).....@Html.ActionLink("Learn More","Details",new { id = item.SessionID })
+                @(((!(string.IsNullOrEmpty(item.Description) ))? item.Description.Substring(0,Math.Min(200,item.Description.Length)):"N/A")).....@Html.ActionLink("Learn More","Details","Sessions",new { id = item.SessionID }, null)
             </div>
         </td>
         @*<td>


### PR DESCRIPTION
Fixes the currently broken link. Note I didn't test this locally, edited in GitHub IDE (dangerous) so a local smoke test probably needed.