### PR TITLE
Fixed two bugs with speakers/details.

### DIFF
--- a/codecampster/Controllers/SpeakersController.cs
+++ b/codecampster/Controllers/SpeakersController.cs
@@ -209,7 +209,7 @@ namespace Codecamp2018.Controllers
 
             // Get the speaker for the supplied session ID
             var speakerVm = from speaker in _context.Speakers
-                            where speaker.ID == sessionVm.FirstOrDefault().SpeakerID
+                            where speaker.ID == id
                             select new SpeakerViewModel
                             {
                                 AvatarURL = speaker.AvatarURL,

--- a/codecampster/Views/Speakers/Details.cshtml
+++ b/codecampster/Views/Speakers/Details.cshtml
@@ -25,7 +25,7 @@
 }
 @if (!string.IsNullOrEmpty(Model.Website))
 {
-    <p><strong>Website:&nbsp;</strong><a target="_blank" href="@(Model.Website.StartsWith("http")?Model.Website:"http://"+Model.Website)>@(Model.Website)" /></p>
+    <p><strong>Website:&nbsp;</strong><a target="_blank" href="@(Model.Website.StartsWith("http")?Model.Website:"http://"+Model.Website)">@(Model.Website) </a></p>
 }
 @if (!string.IsNullOrEmpty(Model.Blog))
 {


### PR DESCRIPTION
If the speaker has no sessions then an exception was thrown since the list of sessions was used when creating the speaker view model. Updated to use the URL ID instead. The second bug was in the Razor for the details view: the link tag was not closed correctly, preventing the website link from working.